### PR TITLE
Remove declaration of FreeCell::card

### DIFF
--- a/card-storage.h
+++ b/card-storage.h
@@ -74,8 +74,6 @@ public:
     const std::optional<Card> topCard() const override;
     std::optional<Card> getCard() override;
 
-    Card const * card() const;
-
 private:
     std::optional<Card> cell_;
 };


### PR DESCRIPTION
I ran into a linking error while trying to use the method in my heuristic since the implementation is missing.

The method was declared in the class, however not implemented. It looks a bit as a left-over from initial versions of the project. `FreeCell::topCard` can be used for the functionality instead. However, since it is declared already (and some students may want to use it), it should probably also be implemented. But let me know if I should just remove the declaration altogether, for now I thought that it would be better to make it an "alias" of `topCard`.