### PR TITLE
Remove unused declaration for function "compute_heuristic"

### DIFF
--- a/search-strategies.h
+++ b/search-strategies.h
@@ -58,8 +58,6 @@ private:
     size_t mem_limit_;
 };
 
-double compute_heuristic(const SearchState &state, AStarHeuristicItf *heuristic);
-
 // beware, this has been proven to NOT be a valid heuristic!
 class OufOfHome_Pseudo : public AStarHeuristicItf {
 public:


### PR DESCRIPTION
There are two declarations for function "compute_heuristic" (one with a pointer and one with a reference), however one is never used and connot be even properly implemented as it does not have access to SearchState private atrributes. The two different declarations may confuse people working with them and they might get stuck wondering, why they got a linker error "Undefined reference to a function compute_heuristic(...)". I removed the unused declaration to prevent this problem.